### PR TITLE
fix pipeline

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -164,7 +164,7 @@ export abstract class StreamBase
                         {
                             this.push(data);
 
-                            if (self.position === self.length)
+                            if (self.position >= self.length)
                                 this.push(null);
                         },
                         err => this.emit("error", err));


### PR DESCRIPTION
Streams are currently not usable in pipeline, the following code will never complete because `self.position === self.length` will never be true as it reads in 16kb blocks. This ends up progressing the position counter forever. This only occurs when you are trying to stream more bytes then the 16kb block.

```
import { pipeline } from 'stream/promises';

async function thisBreaks() {
    const output = new MemoryStream({ length: 1 }); // automatically re-sized.
    const input = new MemoryStream({ data: Buffer.alloc(20000, '1') }): // fill 20,000 length (above the 16kb buffer size) with 1's

    await pipeline(input.asNodeStream(), output.asNodeStream());
    console.log('done');
}

thisBreaks();
```

If you run the above example it will continue to increment the position on the read stream as we never hit the if statement. If you reduce the input size below the buffer size, for example 10000, it will complete as expected.